### PR TITLE
feat: add dark theme and interactive cards

### DIFF
--- a/options.html
+++ b/options.html
@@ -8,78 +8,127 @@
         body {
             font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
             margin: 24px;
+            background: #121212;
+            color: #e0e0e0;
         }
 
         .card {
-            border: 1px solid #ddd;
+            border: 1px solid #333;
             border-radius: 10px;
-            padding: 16px;
             max-width: 760px;
+            background: #1e1e1e;
+            padding: 0;
+            margin: 0;
+            transition: box-shadow 0.2s, transform 0.2s;
+        }
+
+        .card:hover {
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+            transform: translateY(-2px);
+        }
+
+        .card summary {
+            cursor: pointer;
+            padding: 16px;
+            font-size: 16px;
+            font-weight: 600;
+            list-style: none;
+        }
+
+        .card[open] > summary {
+            border-bottom: 1px solid #333;
+            margin-bottom: 8px;
+        }
+
+        .card .content {
+            padding: 0 16px 16px 16px;
         }
 
         code {
-            background: #f6f8fa;
+            background: #2d2d2d;
             padding: 2px 6px;
             border-radius: 6px;
+            color: #f0f0f0;
         }
 
         a.button {
             display: inline-block;
             padding: 8px 12px;
             border-radius: 8px;
-            border: 1px solid #888;
             text-decoration: none;
+            background: #10a37f;
+            color: #fff;
+            border: none;
+            transition: background 0.2s;
+        }
+
+        a.button:hover {
+            background: #0d8c6d;
+        }
+
+        a {
+            color: #58a6ff;
+        }
+
+        a:hover {
+            text-decoration: underline;
         }
     </style>
 </head>
 
 <body>
     <h1>SnapGPT</h1>
-    <div class="card">
-        <h2>Keyboard Shortcut</h2>
-        <p>
-            Chrome requires changing extension shortcuts at
-            <code>chrome://extensions/shortcuts</code>.
-        </p>
-        <p>
-            Open the shortcuts page:
-            <a class="button" href="chrome://extensions/shortcuts" target="_blank" rel="noreferrer">Open shortcuts</a>
-        </p>
-        <p>
-            Look for <strong>“Capture current tab &amp; upload to ChatGPT”</strong> and set your preferred keybinding.
-        </p>
-    </div>
+    <details class="card" open>
+        <summary>Keyboard Shortcut</summary>
+        <div class="content">
+            <p>
+                Chrome requires changing extension shortcuts at
+                <code>chrome://extensions/shortcuts</code>.
+            </p>
+            <p>
+                Open the shortcuts page:
+                <a class="button" href="chrome://extensions/shortcuts" target="_blank" rel="noreferrer">Open shortcuts</a>
+            </p>
+            <p>
+                Look for <strong>“Capture current tab &amp; upload to ChatGPT”</strong> and set your preferred keybinding.
+            </p>
+        </div>
+    </details>
 
-    <div class="card" style="margin-top:16px;">
-        <h2>Behavior</h2>
-        <ul>
-            <li>Captures the visible area of the active tab (Chrome API limitation).</li>
-            <li>Reuses an existing ChatGPT tab if present; otherwise opens a new one.</li>
-            <li>Uploads the screenshot and attempts to auto-send.</li>
-        </ul>
-    </div>
+    <details class="card" style="margin-top:16px;">
+        <summary>Behavior</summary>
+        <div class="content">
+            <ul>
+                <li>Captures the visible area of the active tab (Chrome API limitation).</li>
+                <li>Reuses an existing ChatGPT tab if present; otherwise opens a new one.</li>
+                <li>Uploads the screenshot and attempts to auto-send.</li>
+            </ul>
+        </div>
+    </details>
 
-    <div class="card" style="margin-top:16px;">
-        <h2>Troubleshooting</h2>
-        <h3>If the hotkey doesn't work:</h3>
-        <ol>
-            <li>Make sure the extension is enabled on <a href="chrome://extensions"
-                    target="_blank">chrome://extensions</a></li>
-            <li>Verify no other extension uses the same keyboard shortcut</li>
-            <li>Try using the extension icon in the toolbar as an alternative</li>
-            <li>Check the browser console for errors (right-click > Inspect > Console)</li>
-            <li>For advanced troubleshooting, view the service worker logs:
-                <ul>
-                    <li>Go to <a href="chrome://extensions" target="_blank">chrome://extensions</a></li>
-                    <li>Enable "Developer mode" (top right)</li>
-                    <li>Click "service worker" link under this extension</li>
-                    <li>Look for debug messages or errors in the console</li>
-                </ul>
-            </li>
-            <li>Try our <a href="test.html" target="_blank">test page</a> to see if the extension works there</li>
-        </ol>
-        Version Number: 1.0.2
-    </div>
+    <details class="card" style="margin-top:16px;">
+        <summary>Troubleshooting</summary>
+        <div class="content">
+            <h3>If the hotkey doesn't work:</h3>
+            <ol>
+                <li>Make sure the extension is enabled on <a href="chrome://extensions"
+                        target="_blank">chrome://extensions</a></li>
+                <li>Verify no other extension uses the same keyboard shortcut</li>
+                <li>Try using the extension icon in the toolbar as an alternative</li>
+                <li>Check the browser console for errors (right-click > Inspect > Console)</li>
+                <li>For advanced troubleshooting, view the service worker logs:
+                    <ul>
+                        <li>Go to <a href="chrome://extensions" target="_blank">chrome://extensions</a></li>
+                        <li>Enable "Developer mode" (top right)</li>
+                        <li>Click "service worker" link under this extension</li>
+                        <li>Look for debug messages or errors in the console</li>
+                    </ul>
+                </li>
+                <li>Try our <a href="test.html" target="_blank">test page</a> to see if the extension works there</li>
+            </ol>
+            Version Number: 1.0.2
+        </div>
+    </details>
 </body>
 
 </html>

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,8 @@
             width: 320px;
             margin: 0;
             padding: 0;
-            color: #333;
+            color: #e0e0e0;
+            background: #1e1e1e;
         }
 
         .container {
@@ -22,7 +23,7 @@
             display: flex;
             align-items: center;
             margin-bottom: 16px;
-            border-bottom: 1px solid #eaeaea;
+            border-bottom: 1px solid #333;
             padding-bottom: 12px;
         }
 
@@ -52,11 +53,16 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            transition: background-color 0.2s;
+            transition: background-color 0.2s, transform 0.1s;
         }
 
         .action-button:hover {
             background-color: #0d8c6d;
+            transform: translateY(-1px);
+        }
+
+        .action-button:active {
+            transform: translateY(1px);
         }
 
         .action-button svg {
@@ -64,12 +70,19 @@
         }
 
         .info-box {
-            background-color: #f7f7f7;
+            background-color: #2b2b2b;
             border-radius: 4px;
             padding: 12px;
             font-size: 13px;
             line-height: 1.4;
             margin-bottom: 16px;
+        }
+
+        .info-box summary {
+            cursor: pointer;
+            font-weight: 500;
+            margin-bottom: 8px;
+            list-style: none;
         }
 
         .shortcut {
@@ -80,24 +93,25 @@
         }
 
         .key {
-            background-color: #e5e5e5;
+            background-color: #3a3a3a;
             border-radius: 3px;
             padding: 2px 6px;
             font-family: monospace;
             font-size: 12px;
+            color: #fff;
         }
 
         footer {
             font-size: 12px;
-            color: #777;
+            color: #aaa;
             text-align: center;
             margin-top: 16px;
-            border-top: 1px solid #eaeaea;
+            border-top: 1px solid #333;
             padding-top: 12px;
         }
 
         a {
-            color: #10a37f;
+            color: #58a6ff;
             text-decoration: none;
         }
 
@@ -119,24 +133,24 @@
                 destination:</label>
             <div style="display: flex; align-items: center; gap: 8px;">
                 <select id="destination-select"
-                    style="flex: 1; padding: 8px; border-radius: 4px; border: 1px solid #ddd;">
+                    style="flex: 1; padding: 8px; border-radius: 4px; border: 1px solid #444; background:#1e1e1e; color:#e0e0e0;">
                     <option value="main">Main Chat</option>
                     <option value="loading">Loading folders...</option>
                 </select>
                 <button id="refresh-folders"
-                    style="padding: 8px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; cursor: pointer;"
+                    style="padding: 8px; background: #333; border: 1px solid #444; border-radius: 4px; cursor: pointer;"
                     title="Refresh folder list">
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path
                             d="M13.6654 2.66669L10.3321 6.00002M13.6654 2.66669L9.33203 2.66669M13.6654 2.66669L13.6654 7.00002"
-                            stroke="#555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                            stroke="#ccc" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                         <path
                             d="M2.33203 13.3334L5.66536 10M2.33203 13.3334L6.66536 13.3334M2.33203 13.3334L2.33203 9.00002"
-                            stroke="#555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                            stroke="#ccc" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                     </svg>
                 </button>
             </div>
-            <div style="font-size: 11px; color: #666; margin-top: 4px;">
+            <div style="font-size: 11px; color: #aaa; margin-top: 4px;">
                 <span id="saved-indicator" style="display: none;">✓ Selection saved for future uploads</span>
             </div>
         </div>
@@ -154,7 +168,8 @@
             Capture & Upload Screenshot
         </button>
 
-        <div class="info-box">
+        <details class="info-box" open>
+            <summary>Usage</summary>
             <div class="shortcut">
                 <span>Keyboard shortcut:</span>
                 <span class="key" id="shortcut-key">Ctrl+Shift+Y</span>
@@ -162,13 +177,13 @@
             <p>
                 This will capture the visible area of your current tab and upload it to ChatGPT.
             </p>
-            <p id="shortcut-info" style="font-size: 12px; color: #666;">
+            <p id="shortcut-info" style="font-size: 12px; color: #aaa;">
                 Shortcut will use your saved folder preference
             </p>
             <p id="folder-info" style="margin-top: 8px; font-style: italic; display: none;">
                 Upload to selected folder in ChatGPT.
             </p>
-        </div>
+        </details>
 
         <a href="options.html" target="_blank" id="options-link">Extension Options</a>
 

--- a/test.html
+++ b/test.html
@@ -9,23 +9,50 @@
             margin: 30px;
             line-height: 1.6;
             max-width: 800px;
+            background: #121212;
+            color: #e0e0e0;
         }
 
         .card {
-            border: 1px solid #ddd;
+            border: 1px solid #333;
             border-radius: 8px;
-            padding: 15px;
             margin-bottom: 20px;
+            background: #1e1e1e;
+            padding: 0;
+            transition: box-shadow 0.2s, transform 0.2s;
+        }
+
+        .card:hover {
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+            transform: translateY(-2px);
+        }
+
+        .card summary {
+            cursor: pointer;
+            padding: 15px;
+            font-size: 18px;
+            font-weight: 600;
+            list-style: none;
+        }
+
+        .card[open] > summary {
+            border-bottom: 1px solid #333;
+            margin-bottom: 10px;
+        }
+
+        .card .content {
+            padding: 0 15px 15px 15px;
         }
 
         h1 {
-            color: #333;
+            color: #e0e0e0;
         }
 
         code {
-            background-color: #f4f4f4;
+            background-color: #2d2d2d;
             padding: 2px 5px;
             border-radius: 3px;
+            color: #f0f0f0;
         }
     </style>
 </head>
@@ -33,36 +60,42 @@
 <body>
     <h1>ChatGPT Screenshot Uploader Test Page</h1>
 
-    <div class="card">
-        <h2>Hotkey Test</h2>
-        <p>Press <code>Ctrl+Shift+Y</code> (Windows) or <code>Command+Shift+Y</code> (Mac) on this page to test the
-            screenshot functionality.</p>
-        <p>If it works, ChatGPT should open with this page as a screenshot.</p>
-    </div>
+    <details class="card" open>
+        <summary>Hotkey Test</summary>
+        <div class="content">
+            <p>Press <code>Ctrl+Shift+Y</code> (Windows) or <code>Command+Shift+Y</code> (Mac) on this page to test the
+                screenshot functionality.</p>
+            <p>If it works, ChatGPT should open with this page as a screenshot.</p>
+        </div>
+    </details>
 
-    <div class="card">
-        <h2>Troubleshooting</h2>
-        <p>If the hotkey doesn't work:</p>
-        <ol>
-            <li>Open Chrome's extension page: <code>chrome://extensions</code></li>
-            <li>Find this extension and click on "Details"</li>
-            <li>Check "Allow in Incognito" if you're trying to use it there</li>
-            <li>Make sure "Site access" is set appropriately</li>
-            <li>Click "Extension options" and verify shortcuts</li>
-            <li>Try clicking the extension icon in the toolbar (should also work)</li>
-        </ol>
-    </div>
+    <details class="card">
+        <summary>Troubleshooting</summary>
+        <div class="content">
+            <p>If the hotkey doesn't work:</p>
+            <ol>
+                <li>Open Chrome's extension page: <code>chrome://extensions</code></li>
+                <li>Find this extension and click on "Details"</li>
+                <li>Check "Allow in Incognito" if you're trying to use it there</li>
+                <li>Make sure "Site access" is set appropriately</li>
+                <li>Click "Extension options" and verify shortcuts</li>
+                <li>Try clicking the extension icon in the toolbar (should also work)</li>
+            </ol>
+        </div>
+    </details>
 
-    <div class="card">
-        <h2>Console Output</h2>
-        <p>Check Chrome's DevTools console for the extension by:</p>
-        <ol>
-            <li>Go to <code>chrome://extensions</code></li>
-            <li>Enable "Developer mode" (top right)</li>
-            <li>Click on "background page" link under this extension</li>
-            <li>Look for debug messages in the console</li>
-        </ol>
-    </div>
+    <details class="card">
+        <summary>Console Output</summary>
+        <div class="content">
+            <p>Check Chrome's DevTools console for the extension by:</p>
+            <ol>
+                <li>Go to <code>chrome://extensions</code></li>
+                <li>Enable "Developer mode" (top right)</li>
+                <li>Click on "background page" link under this extension</li>
+                <li>Look for debug messages in the console</li>
+            </ol>
+        </div>
+    </details>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- adopt dark theme across options, popup, and test pages
- add collapsible sections and hover animations for a cleaner, more interactive UI
- modernize folder selection and button styles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a24b5f725c8324b10deeda3e089a7d